### PR TITLE
fix(utiles): evitar dependencia de junit-bom y fijar versión de JUnit para tests

### DIFF
--- a/utiles/pom.xml
+++ b/utiles/pom.xml
@@ -24,7 +24,6 @@
         <maven.compiler.release>21</maven.compiler.release>
         <logback.version>1.5.25</logback.version>
         <slf4j.version>2.0.16</slf4j.version>
-        <junit.version>5.11.4</junit.version>
     </properties>
 
 
@@ -43,24 +42,12 @@
             <url>https://maven.pkg.github.com/hamfree/PUBLICO</url>
         </repository>
     </distributionManagement>
-    
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.junit</groupId>
-                <artifactId>junit-bom</artifactId>
-                <version>${junit.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
-    
     <dependencies>
         <!-- Tests -->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-engine</artifactId>
+            <version>5.11.0</version>
             <scope>test</scope>
         </dependency>
         


### PR DESCRIPTION
### Motivation
- La importación del BOM `org.junit:junit-bom` y la propiedad `junit.version` dejaban a `junit-jupiter-engine` sin una versión explícita cuando el BOM no se resolvía, provocando fallos de resolución de modelo en entornos con acceso restringido a Maven Central. 

### Description
- Eliminado `junit.version` de las `properties` en `utiles/pom.xml`.
- Eliminado el bloque `dependencyManagement` que importaba `org.junit:junit-bom` desde el BOM.
- Añadida la versión explícita `5.11.0` a la dependencia `org.junit.jupiter:junit-jupiter-engine` en las dependencias de test.
- Cambio localizado en `utiles/pom.xml` para que la resolución de dependencias de tests no dependa del BOM externo.

### Testing
- Ejecuté `mvn test -q` en `utiles/` antes del cambio y la ejecución falló con un error de resolución del BOM (`org.junit:junit-bom`) y una dependencia sin versión, reproduciendo el problema original. 
- Tras los cambios volví a ejecutar `mvn test -q` y ya no aparece el fallo de BOM/version de JUnit; el build ahora falla por resolución de plugins (por ejemplo `maven-enforcer-plugin`) debido a respuestas `403 Forbidden` desde Maven Central en este entorno, por lo que los tests unitarios no pudieron completarse aquí.
- No se ejecutaron tests unitarios adicionales locales porque la infraestructura bloquea la descarga de artefactos/plugins necesarios.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699af9511ef8832a9563a371513e1e21)